### PR TITLE
ARTEMIS-3337: Correctly handle multiple connection failures

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
@@ -823,11 +823,15 @@ public class ActiveMQSessionContext extends SessionContext {
    }
 
    @Override
+   public void transferConnection(RemotingConnection newConnection) {
+      this.remotingConnection = newConnection;
+      sessionChannel.transferConnection((CoreRemotingConnection) newConnection);
+   }
+
+   @Override
    public boolean reattachOnNewConnection(RemotingConnection newConnection) throws ActiveMQException {
 
-      this.remotingConnection = newConnection;
-
-      sessionChannel.transferConnection((CoreRemotingConnection) newConnection);
+      transferConnection(newConnection);
 
       Packet request = new ReattachSessionMessage(name, sessionChannel.getLastConfirmedCommandID());
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
@@ -70,6 +70,11 @@ public abstract class SessionContext {
    public abstract int getReconnectID();
 
    /**
+    * Transfers the session context to the given newConnection on the client-side
+    */
+   public abstract void transferConnection(RemotingConnection newConnection);
+
+   /**
     * it will either reattach or reconnect, preferably reattaching it.
     *
     * @param newConnection


### PR DESCRIPTION
Previously, when during reconnect one session couldn't be transferred
to the new connection, we instantly returned and didn't execute failover
for the other sessions. This produced the issue that for sessions
where no failover was executed, their channels were still present on the
old connection. When the old connection was then destroyed, these channels
were closed although the reconnect was still ongoing, which lead to
"dead" sessions.

Now, if a session failover fails, for the remaining sessions the "client-side" part
of failover is executed, which removes the sessions from the old connection so that
they are not closed when the old connection is closed afterwards.