### PR TITLE
ARTEMIS-3352: remove redundant snapshot repo definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,12 +231,6 @@
          <url>${staging.siteURL}/maven/${project.version}</url>
          <!--<url>${site-repo-url}</url>-->
       </site>
-      <snapshotRepository>
-         <id>apache.snapshots.https</id>
-         <name>Apache Development Snapshot Repository</name>
-         <url>https://repository.apache.org/content/repositories/snapshots</url>
-         <uniqueVersion>false</uniqueVersion>
-      </snapshotRepository>
    </distributionManagement>
 
    <issueManagement>


### PR DESCRIPTION
Parent defines it already, and Maven 3 ignores the 'uniqueVersion' config