### PR TITLE
ARTEMIS-3327 Reverting 60aac65acf748d4851fb1dac36d93e034ed9c5c4 and a…

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -935,6 +935,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          throw ActiveMQJournalBundle.BUNDLE.recordLargerThanStoreMax(addRecordEncodeSize, maxRecordSize);
       }
 
+      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(sync, callback);
       appendExecutor.execute(new Runnable() {
          @Override
          public void run() {
@@ -951,9 +952,12 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                                   ", usedFile = " +
                                   usedFile);
                }
+               result.set(true);
             } catch (ActiveMQShutdownException e) {
+               result.fail(e);
                logger.error("appendAddRecord:" + e, e);
             } catch (Throwable e) {
+               result.fail(e);
                setErrorCondition(callback, null, e);
                logger.error("appendAddRecord::"  + e, e);
             } finally {
@@ -961,6 +965,8 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
             }
          }
       });
+
+      result.get();
    }
 
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
@@ -43,6 +43,9 @@ public class FakeSequentialFileFactory implements SequentialFileFactory {
 
    private final boolean supportsCallback;
 
+
+   private Runnable writeDirectCallback;
+
    private volatile boolean holdCallbacks;
 
    private ListenerHoldCallback holdCallbackListener;
@@ -79,6 +82,10 @@ public class FakeSequentialFileFactory implements SequentialFileFactory {
    @Override
    public int getMaxIO() {
       return 1;
+   }
+
+   public void setWriteDirectCallback(Runnable writeDirectCallback) {
+      this.writeDirectCallback = writeDirectCallback;
    }
 
    // Public --------------------------------------------------------
@@ -418,6 +425,10 @@ public class FakeSequentialFileFactory implements SequentialFileFactory {
             addCallback(bytes, action);
          } else {
             action.run();
+         }
+
+         if (writeDirectCallback != null) {
+            writeDirectCallback.run();
          }
 
       }


### PR DESCRIPTION
…dding test to validate

contract with sync.

This reverts commit (ARTEMIS-3327 Removing unecessary block operation on journal append record) 60aac65acf748d4851fb1dac36d93e034ed9c5c4 .

However this is adding two tests to make sure there won't be a regression on this.