### PR TITLE
ARTEMIS-3381 AMQP bypasses session when deleting queues

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -642,7 +642,7 @@ public class AMQPSessionCallback implements SessionCallback {
    }
 
    public void deleteQueue(SimpleString queueName) throws Exception {
-      manager.getServer().destroyQueue(queueName);
+      serverSession.deleteQueue(queueName);
    }
 
    public void resetContext(OperationContext oldContext) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SecureConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SecureConfigurationTest.java
@@ -120,7 +120,7 @@ public class SecureConfigurationTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void testSecureDurableSubscriber() throws Exception {
+   public void testCreateSecureDurableSubscriber() throws Exception {
       ConnectionFactory connectionFactory = getConnectionFactory("b", "b");
       String message = "blah";
 
@@ -131,6 +131,23 @@ public class SecureConfigurationTest extends ActiveMQTestBase {
       try {
          sendAndReceiveTextUsingTopic(connectionFactory, "clientId", message, "secured_topic_durable", (t, s) -> s.createDurableSubscriber(t, "secured_topic_durable/non-existant-queue"));
          Assert.fail("Security exception expected, but did not occur, excepetion expected as not permissioned to dynamically create queue");
+      } catch (JMSSecurityException j) {
+         //Expected exception
+      }
+   }
+
+   @Test
+   public void testDeleteSecureDurableSubscriber() throws Exception {
+      ConnectionFactory connectionFactory = getConnectionFactory("c", "c");
+      String message = "blah";
+
+      //Expect to be able to create durable queue for subscription
+      String messageRecieved = sendAndReceiveTextUsingTopic(connectionFactory, "clientId", message, "secured_topic_durable", (t, s) -> s.createDurableSubscriber(t, "secured_topic_durable/non-existant-queue"));
+      Assert.assertEquals(message, messageRecieved);
+
+      try {
+         sendAndReceiveTextUsingTopic(connectionFactory, "clientId", message, "secured_topic_durable", (t, s) -> s.createDurableSubscriber(t, "secured_topic_durable/non-existant-queue", "age > 10", false));
+         Assert.fail("Security exception expected, but did not occur, excepetion expected as not permissioned to dynamically delete queue");
       } catch (JMSSecurityException j) {
          //Expected exception
       }

--- a/tests/integration-tests/src/test/resources/multicast_topic.xml
+++ b/tests/integration-tests/src/test/resources/multicast_topic.xml
@@ -127,11 +127,11 @@ under the License.
          <security-setting match="secured_topic_durable">
             <permission type="createNonDurableQueue" roles="a"/>
             <permission type="deleteNonDurableQueue" roles="a"/>
-            <permission type="createDurableQueue" roles="a"/>
+            <permission type="createDurableQueue" roles="a,c"/>
             <permission type="deleteDurableQueue" roles="a"/>
             <permission type="browse" roles="a"/>
-            <permission type="send" roles="a,b"/>
-            <permission type="consume" roles="a,b" />
+            <permission type="send" roles="a,b,c"/>
+            <permission type="consume" roles="a,b,c" />
             <!-- we need this otherwise ./artemis data imp wouldn't work -->
             <permission type="manage" roles="a"/>
          </security-setting>


### PR DESCRIPTION
The AMQP implementation bypasses the ServerSession when deleting queues
which also bypasses security authorization.