### PR TITLE
ARTEMIS-3400 add audit logging for message ack

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2437,6 +2437,15 @@ public interface AuditLogger extends BasicLogger {
    @Message(id = 601501, value = "User {0} is consuming a message from {1}: {2}", format = Message.Format.MESSAGE_FORMAT)
    void consumeMessage(String user, String address, String message);
 
+   //hot path log using a different logger
+   static void coreAcknowledgeMessage(Subject user, String remoteAddress, String queue, String message) {
+      MESSAGE_LOGGER.acknowledgeMessage(getCaller(user, remoteAddress), queue, message);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601502, value = "User {0} is acknowledging a message from {1}: {2}", format = Message.Format.MESSAGE_FORMAT)
+   void acknowledgeMessage(String user, String queue, String message);
+
    /*
     * This logger is focused on user interaction from the console or thru resource specific functions in the management layer/JMX
     * */

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerAMQPMutualSSLTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerAMQPMutualSSLTest.java
@@ -85,5 +85,6 @@ public class AuditLoggerAMQPMutualSSLTest extends AuditLoggerTestBase {
       checkAuditLogRecord(true, "AMQ601500: User myUser(producers)@", "is sending a message AMQPStandardMessage");
       checkAuditLogRecord(true, "AMQ601265: User myUser(producers)@", "is creating a core consumer");
       checkAuditLogRecord(true, "AMQ601501: User myUser(producers)@", "is consuming a message from exampleQueue");
+      checkAuditLogRecord(true, "AMQ601502: User myUser(producers)@", "is acknowledging a message from exampleQueue: AMQPStandardMessage");
    }
 }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
@@ -171,9 +171,10 @@ public class AuditLoggerTest extends AuditLoggerTestBase {
          Assert.assertNotNull(clientMessage);
          clientMessage = consumer.receive(5000);
          Assert.assertNotNull(clientMessage);
-         checkAuditLogRecord(true, "is consuming a message from");
       } finally {
          connection.close();
       }
+      checkAuditLogRecord(true, "is consuming a message from");
+      checkAuditLogRecord(true, "is acknowledging a message from");
    }
 }


### PR DESCRIPTION
Aside from adding audit logging for message acknowledgement this commit
also consolidates the two nearly identical acknowledge method
implementations in o.a.a.a.c.s.i.QueueImpl. This avoids duplicating
code for audit logging, plugin invocation, etc. There is no semantic
change.