### PR TITLE
ARTEMIS-3304: replace use of deprecated constructors marked as for-re…

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
@@ -79,7 +79,7 @@ public class TestConversions extends Assert {
          bodyBytes[i] = (byte) 0xff;
       }
 
-      message.setBody(new AmqpValue(new Boolean(true)));
+      message.setBody(new AmqpValue(Boolean.valueOf(true)));
 
       AMQPMessage encodedMessage = encodeAndCreateAMQPMessage(message);
 
@@ -181,7 +181,7 @@ public class TestConversions extends Assert {
       message.setApplicationProperties(properties);
 
       List<Object> objects = new LinkedList<>();
-      objects.add(new Integer(10));
+      objects.add(Integer.valueOf(10));
       objects.add("10");
 
       message.setBody(new AmqpSequence(objects));

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/broker/BrokerBenchmark.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/broker/BrokerBenchmark.java
@@ -55,9 +55,9 @@ public class BrokerBenchmark extends BrokerTestSupport {
 
    public void initCombosForTestPerformance() {
       addCombinationValues("destination", new Object[]{new ActiveMQQueue("TEST"), new ActiveMQTopic("TEST")});
-      addCombinationValues("PRODUCER_COUNT", new Object[]{new Integer("1"), new Integer("10")});
-      addCombinationValues("CONSUMER_COUNT", new Object[]{new Integer("1"), new Integer("10")});
-      addCombinationValues("CONSUMER_COUNT", new Object[]{new Integer("1"), new Integer("10")});
+      addCombinationValues("PRODUCER_COUNT", new Object[]{Integer.valueOf("1"), Integer.valueOf("10")});
+      addCombinationValues("CONSUMER_COUNT", new Object[]{Integer.valueOf("1"), Integer.valueOf("10")});
+      addCombinationValues("CONSUMER_COUNT", new Object[]{Integer.valueOf("1"), Integer.valueOf("10")});
       addCombinationValues("deliveryMode", new Object[]{Boolean.TRUE});
    }
 

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQBytesMessageTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQBytesMessageTest.java
@@ -242,8 +242,8 @@ public class ActiveMQBytesMessageTest extends TestCase {
          msg.writeObject(Short.valueOf((short) 3));
          msg.writeObject(Integer.valueOf(3));
          msg.writeObject(Long.valueOf(300L));
-         msg.writeObject(new Float(3.3f));
-         msg.writeObject(new Double(3.3));
+         msg.writeObject(Float.valueOf(3.3f));
+         msg.writeObject(Double.valueOf(3.3));
          msg.writeObject(new byte[3]);
       } catch (MessageFormatException mfe) {
          fail("objectified primitives should be allowed");

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMapMessageTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMapMessageTest.java
@@ -235,7 +235,7 @@ public class ActiveMQMapMessageTest extends TestCase {
       Boolean booleanValue = Boolean.TRUE;
       Byte byteValue = Byte.valueOf("1");
       byte[] bytesValue = new byte[3];
-      Character charValue = new Character('a');
+      Character charValue = Character.valueOf('a');
       Double doubleValue = Double.valueOf("1.5");
       Float floatValue = Float.valueOf("1.5");
       Integer intValue = Integer.valueOf("1");

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQStreamMessageTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQStreamMessageTest.java
@@ -138,7 +138,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readLong() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Byte(test).toString()));
+         assertTrue(msg.readString().equals(Byte.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -187,7 +187,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readLong() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Short(test).toString()));
+         assertTrue(msg.readString().equals(Short.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -238,7 +238,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readChar() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Character(test).toString()));
+         assertTrue(msg.readString().equals(Character.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -303,7 +303,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readLong() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Integer(test).toString()));
+         assertTrue(msg.readString().equals(Integer.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -410,10 +410,10 @@ public class ActiveMQStreamMessageTest extends TestCase {
          } catch (MessageFormatException mfe) {
          }
          msg = new ActiveMQStreamMessage();
-         msg.writeObject(new Long("1"));
+         msg.writeObject(Long.valueOf("1"));
          // reset so it's readable now
          msg.reset();
-         assertEquals(new Long("1"), msg.readObject());
+         assertEquals(Long.valueOf("1"), msg.readObject());
       } catch (JMSException jmsEx) {
          jmsEx.printStackTrace();
          assertTrue(false);
@@ -430,7 +430,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readDouble() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Float(test).toString()));
+         assertTrue(msg.readString().equals(Float.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -487,7 +487,7 @@ public class ActiveMQStreamMessageTest extends TestCase {
          msg.reset();
          assertTrue(msg.readDouble() == test);
          msg.reset();
-         assertTrue(msg.readString().equals(new Double(test).toString()));
+         assertTrue(msg.readString().equals(Double.valueOf(test).toString()));
          msg.reset();
          try {
             msg.readBoolean();
@@ -547,32 +547,32 @@ public class ActiveMQStreamMessageTest extends TestCase {
       ActiveMQStreamMessage msg = new ActiveMQStreamMessage();
       try {
          byte testByte = (byte) 2;
-         msg.writeString(new Byte(testByte).toString());
+         msg.writeString(Byte.valueOf(testByte).toString());
          msg.reset();
          assertTrue(msg.readByte() == testByte);
          msg.clearBody();
          short testShort = 3;
-         msg.writeString(new Short(testShort).toString());
+         msg.writeString(Short.valueOf(testShort).toString());
          msg.reset();
          assertTrue(msg.readShort() == testShort);
          msg.clearBody();
          int testInt = 4;
-         msg.writeString(new Integer(testInt).toString());
+         msg.writeString(Integer.valueOf(testInt).toString());
          msg.reset();
          assertTrue(msg.readInt() == testInt);
          msg.clearBody();
          long testLong = 6L;
-         msg.writeString(new Long(testLong).toString());
+         msg.writeString(Long.valueOf(testLong).toString());
          msg.reset();
          assertTrue(msg.readLong() == testLong);
          msg.clearBody();
          float testFloat = 6.6f;
-         msg.writeString(new Float(testFloat).toString());
+         msg.writeString(Float.valueOf(testFloat).toString());
          msg.reset();
          assertTrue(msg.readFloat() == testFloat);
          msg.clearBody();
          double testDouble = 7.7d;
-         msg.writeString(new Double(testDouble).toString());
+         msg.writeString(Double.valueOf(testDouble).toString());
          msg.reset();
          assertTrue(msg.readDouble() == testDouble);
          msg.clearBody();
@@ -754,10 +754,10 @@ public class ActiveMQStreamMessageTest extends TestCase {
    public void testClearBody() throws JMSException {
       ActiveMQStreamMessage streamMessage = new ActiveMQStreamMessage();
       try {
-         streamMessage.writeObject(new Long(2));
+         streamMessage.writeObject(Long.valueOf(2));
          streamMessage.clearBody();
          assertFalse(streamMessage.isReadOnlyBody());
-         streamMessage.writeObject(new Long(2));
+         streamMessage.writeObject(Long.valueOf(2));
          streamMessage.readObject();
          fail("should throw exception");
       } catch (MessageNotReadableException mnwe) {
@@ -974,14 +974,14 @@ public class ActiveMQStreamMessageTest extends TestCase {
          ActiveMQStreamMessage message = new ActiveMQStreamMessage();
          message.clearBody();
          message.writeObject("test");
-         message.writeObject(new Character('a'));
-         message.writeObject(new Boolean(false));
-         message.writeObject(new Byte((byte) 2));
-         message.writeObject(new Short((short) 2));
-         message.writeObject(new Integer(2));
-         message.writeObject(new Long(2L));
-         message.writeObject(new Float(2.0f));
-         message.writeObject(new Double(2.0d));
+         message.writeObject(Character.valueOf('a'));
+         message.writeObject(Boolean.valueOf(false));
+         message.writeObject(Byte.valueOf((byte) 2));
+         message.writeObject(Short.valueOf((short) 2));
+         message.writeObject(Integer.valueOf(2));
+         message.writeObject(Long.valueOf(2L));
+         message.writeObject(Float.valueOf(2.0f));
+         message.writeObject(Double.valueOf(2.0d));
       } catch (Exception e) {
          fail(e.getMessage());
       }

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/demo/SimpleProducer.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/demo/SimpleProducer.java
@@ -82,7 +82,7 @@ public final class SimpleProducer {
       destinationName = args[0];
       LOG.info("Destination name is " + destinationName);
       if (args.length == 2) {
-         numMsgs = (new Integer(args[1])).intValue();
+         numMsgs = (Integer.valueOf(args[1])).intValue();
       } else {
          numMsgs = 1;
       }

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/demo/SimpleQueueSender.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/demo/SimpleQueueSender.java
@@ -82,7 +82,7 @@ public final class SimpleQueueSender {
       queueName = args[0];
       LOG.info("Queue name is " + queueName);
       if (args.length == 2) {
-         numMsgs = (new Integer(args[1])).intValue();
+         numMsgs = (Integer.valueOf(args[1])).intValue();
       } else {
          numMsgs = 1;
       }

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/network/DemandForwardingBridgeTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/network/DemandForwardingBridgeTest.java
@@ -39,8 +39,8 @@ public class DemandForwardingBridgeTest extends NetworkTestSupport {
    private DemandForwardingBridge bridge;
 
    public void initCombosForTestSendThenAddConsumer() {
-      addCombinationValues("deliveryMode", new Object[]{new Integer(DeliveryMode.NON_PERSISTENT), new Integer(DeliveryMode.PERSISTENT)});
-      addCombinationValues("destinationType", new Object[]{new Byte(ActiveMQDestination.QUEUE_TYPE)});
+      addCombinationValues("deliveryMode", new Object[]{Integer.valueOf(DeliveryMode.NON_PERSISTENT), Integer.valueOf(DeliveryMode.PERSISTENT)});
+      addCombinationValues("destinationType", new Object[]{Byte.valueOf(ActiveMQDestination.QUEUE_TYPE)});
    }
 
    public void testSendThenAddConsumer() throws Exception {
@@ -109,8 +109,8 @@ public class DemandForwardingBridgeTest extends NetworkTestSupport {
    }
 
    public void initCombosForTestAddConsumerThenSend() {
-      addCombinationValues("deliveryMode", new Object[]{new Integer(DeliveryMode.NON_PERSISTENT), new Integer(DeliveryMode.PERSISTENT)});
-      addCombinationValues("destinationType", new Object[]{new Byte(ActiveMQDestination.QUEUE_TYPE), new Byte(ActiveMQDestination.TOPIC_TYPE)});
+      addCombinationValues("deliveryMode", new Object[]{Integer.valueOf(DeliveryMode.NON_PERSISTENT), Integer.valueOf(DeliveryMode.PERSISTENT)});
+      addCombinationValues("destinationType", new Object[]{Byte.valueOf(ActiveMQDestination.QUEUE_TYPE), Byte.valueOf(ActiveMQDestination.TOPIC_TYPE)});
    }
 
    public void testAddConsumerThenSend() throws Exception {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/network/ForwardingBridgeTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/network/ForwardingBridgeTest.java
@@ -37,8 +37,8 @@ public class ForwardingBridgeTest extends NetworkTestSupport {
    private ForwardingBridge bridge;
 
    public void initCombosForTestForwardMessageCompressed() {
-      addCombinationValues("deliveryMode", new Object[]{new Integer(DeliveryMode.NON_PERSISTENT), new Integer(DeliveryMode.PERSISTENT)});
-      addCombinationValues("destinationType", new Object[]{new Byte(ActiveMQDestination.QUEUE_TYPE), new Byte(ActiveMQDestination.TOPIC_TYPE)});
+      addCombinationValues("deliveryMode", new Object[]{Integer.valueOf(DeliveryMode.NON_PERSISTENT), Integer.valueOf(DeliveryMode.PERSISTENT)});
+      addCombinationValues("destinationType", new Object[]{Byte.valueOf(ActiveMQDestination.QUEUE_TYPE), Byte.valueOf(ActiveMQDestination.TOPIC_TYPE)});
    }
 
    public void testForwardMessageCompressed() throws Exception {
@@ -85,8 +85,8 @@ public class ForwardingBridgeTest extends NetworkTestSupport {
    }
 
    public void initCombosForTestAddConsumerThenSend() {
-      addCombinationValues("deliveryMode", new Object[]{new Integer(DeliveryMode.NON_PERSISTENT), new Integer(DeliveryMode.PERSISTENT)});
-      addCombinationValues("destinationType", new Object[]{new Byte(ActiveMQDestination.QUEUE_TYPE), new Byte(ActiveMQDestination.TOPIC_TYPE)});
+      addCombinationValues("deliveryMode", new Object[]{Integer.valueOf(DeliveryMode.NON_PERSISTENT), Integer.valueOf(DeliveryMode.PERSISTENT)});
+      addCombinationValues("destinationType", new Object[]{Byte.valueOf(ActiveMQDestination.QUEUE_TYPE), Byte.valueOf(ActiveMQDestination.TOPIC_TYPE)});
    }
 
    public void testAddConsumerThenSend() throws Exception {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/test/message/NestedMapAndListPropertyTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/test/message/NestedMapAndListPropertyTest.java
@@ -43,8 +43,8 @@ public class NestedMapAndListPropertyTest extends JmsTopicSendReceiveWithTwoConn
       Map map = (Map) message.getObjectProperty("mapField");
       assertNotNull(map);
       assertEquals("mapField.a", "foo", map.get("a"));
-      assertEquals("mapField.b", new Integer(23), map.get("b"));
-      assertEquals("mapField.c", new Long(45), map.get("c"));
+      assertEquals("mapField.b", Integer.valueOf(23), map.get("b"));
+      assertEquals("mapField.c", Long.valueOf(45), map.get("c"));
 
       value = map.get("d");
       assertTrue("mapField.d should be a Map", value instanceof Map);
@@ -80,8 +80,8 @@ public class NestedMapAndListPropertyTest extends JmsTopicSendReceiveWithTwoConn
 
       Map<String, Object> nestedMap = new HashMap<>();
       nestedMap.put("a", "foo");
-      nestedMap.put("b", new Integer(23));
-      nestedMap.put("c", new Long(45));
+      nestedMap.put("b", Integer.valueOf(23));
+      nestedMap.put("c", Long.valueOf(45));
       nestedMap.put("d", grandChildMap);
 
       answer.setObjectProperty("mapField", nestedMap);

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/tcp/SocketTstFactory.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/tcp/SocketTstFactory.java
@@ -74,7 +74,7 @@ public class SocketTstFactory extends SocketFactory {
                            lastDelayVal += 1;
                      }
 
-                     lastDelay = new Integer(lastDelayVal);
+                     lastDelay = Integer.valueOf(lastDelayVal);
 
                      LOG.info("Trying to close client socket " + socket.toString() + " in " + lastDelayVal + " milliseconds");
 

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/DurableSubscriptionReactivationTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/DurableSubscriptionReactivationTest.java
@@ -35,7 +35,7 @@ public class DurableSubscriptionReactivationTest extends EmbeddedBrokerTestSuppo
    public boolean keepDurableSubsActive;
 
    public void initCombosForTestReactivateKeepaliveSubscription() {
-      addCombinationValues("keepDurableSubsActive", new Object[]{new Boolean(true), new Boolean(false)});
+      addCombinationValues("keepDurableSubsActive", new Object[]{Boolean.valueOf(true), Boolean.valueOf(false)});
    }
 
    public void testReactivateKeepaliveSubscription() throws Exception {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/NetworkBridgeProducerFlowControlTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/NetworkBridgeProducerFlowControlTest.java
@@ -113,8 +113,8 @@ public class NetworkBridgeProducerFlowControlTest extends JmsMultipleBrokersTest
    }
 
    public void initCombosForTestFastAndSlowRemoteConsumers() {
-      addCombinationValues("persistentTestMessages", new Object[]{new Boolean(true), new Boolean(false)});
-      addCombinationValues("networkIsAlwaysSendSync", new Object[]{new Boolean(true), new Boolean(false)});
+      addCombinationValues("persistentTestMessages", new Object[]{Boolean.valueOf(true), Boolean.valueOf(false)});
+      addCombinationValues("networkIsAlwaysSendSync", new Object[]{Boolean.valueOf(true), Boolean.valueOf(false)});
    }
 
    @Override

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/util/ReflectionSupportTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/util/ReflectionSupportTest.java
@@ -105,7 +105,7 @@ public class ReflectionSupportTest extends TestCase {
 
    public static class TestWitBoolean {
 
-      private Boolean keepAlive = new Boolean(false);
+      private Boolean keepAlive = Boolean.valueOf(false);
 
       public Boolean getKeepAlive() {
          return keepAlive;

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
@@ -153,7 +153,7 @@ public final class TypeConversionSupport {
       CONVERSION_MAP.put(new ConversionKey(Float.class, Double.class), new Converter() {
          @Override
          public Object convert(Object value) {
-            return new Double(((Number) value).doubleValue());
+            return Double.valueOf(((Number) value).doubleValue());
          }
       });
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMXManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMXManagementTest.java
@@ -149,7 +149,7 @@ public class JMXManagementTest extends JMSClientTestSupport {
 
       try {
          UUID uuid = UUID.randomUUID();
-         Character character = new Character('C');
+         Character character = Character.valueOf('C');
          AmqpSession session = connection.createSession();
          AmqpSender sender = session.createSender(getQueueName());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
@@ -554,10 +554,10 @@ public class BridgeReconnectTest extends BridgeTestBase {
       HashMap<Integer, AtomicInteger> counts = countJournal(server1.getConfiguration());
       if (persistCache) {
          // There should be one record per message
-         Assert.assertEquals(numMessages, counts.get(new Integer(JournalRecordIds.DUPLICATE_ID)).intValue());
+         Assert.assertEquals(numMessages, counts.get(Integer.valueOf(JournalRecordIds.DUPLICATE_ID)).intValue());
       } else {
          // no cache means there shouldn't be an id anywhere
-         Assert.assertNull(counts.get(new Integer(JournalRecordIds.DUPLICATE_ID)));
+         Assert.assertNull(counts.get(Integer.valueOf(JournalRecordIds.DUPLICATE_ID)));
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
@@ -1180,7 +1180,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
             Integer c = consumerCounts.get(tn);
             if (c == null) {
-               c = new Integer(cnt);
+               c = Integer.valueOf(cnt);
             }
 
             if (tn == threadNum && cnt != c.intValue()) {
@@ -1250,7 +1250,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
          Integer c = counts.get(threadNum);
          if (c == null) {
-            c = new Integer(cnt);
+            c = Integer.valueOf(cnt);
          }
 
          if (tn == threadNum && cnt != c.intValue()) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/crossprotocol/RequestReplyNonJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/crossprotocol/RequestReplyNonJMSTest.java
@@ -102,7 +102,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message = new AmqpMessage();
          message.setReplyToAddress(replyQueue.toString());
-         message.setMessageAnnotation("x-opt-jms-reply-to", new Byte((byte)10)); // that's invalid on the conversion, lets hope it doesn't fail
+         message.setMessageAnnotation("x-opt-jms-reply-to", Byte.valueOf((byte)10)); // that's invalid on the conversion, lets hope it doesn't fail
          message.setMessageId("msg-1");
          sender.send(message);
 
@@ -201,7 +201,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message.setReplyToAddress(replyQueue.toString());
          message.setMessageId("msg-1");
-         message.setMessageAnnotation("x-opt-not-jms-reply-to", new Byte((byte)1));
+         message.setMessageAnnotation("x-opt-not-jms-reply-to", Byte.valueOf((byte)1));
          message.setText("Test-Message");
          sender.send(message);
 
@@ -251,7 +251,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message.setReplyToAddress(replyQueue.toString());
          message.setMessageId("msg-1");
-         message.setMessageAnnotation("x-opt-jms-reply-to", new Byte((byte)0));
+         message.setMessageAnnotation("x-opt-jms-reply-to", Byte.valueOf((byte)0));
          message.setText("Test-Message");
          sender.send(message);
 
@@ -301,7 +301,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message.setReplyToAddress(topicName.toString());
          message.setMessageId("msg-1");
-         message.setMessageAnnotation("x-opt-jms-reply-to", new Byte((byte)1));
+         message.setMessageAnnotation("x-opt-jms-reply-to", Byte.valueOf((byte)1));
          message.setText("Test-Message");
          sender.send(message);
 
@@ -353,7 +353,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message.setReplyToAddress(replyToName);
          message.setMessageId("msg-1");
-         message.setMessageAnnotation("x-opt-jms-reply-to", new Byte((byte)3));
+         message.setMessageAnnotation("x-opt-jms-reply-to", Byte.valueOf((byte)3));
          message.setText("Test-Message");
          sender.send(message);
 
@@ -404,7 +404,7 @@ public class RequestReplyNonJMSTest extends OpenWireTestBase {
          AmqpMessage message = new AmqpMessage();
          message.setReplyToAddress(replyToName);
          message.setMessageId("msg-1");
-         message.setMessageAnnotation("x-opt-jms-reply-to", new Byte((byte)2));
+         message.setMessageAnnotation("x-opt-jms-reply-to", Byte.valueOf((byte)2));
          message.setText("Test-Message");
          sender.send(message);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -1450,7 +1450,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       final HashMap<Integer, AtomicInteger> recordsType = countJournal(config);
 
-      assertNull("The system is acking page records instead of just delete data", recordsType.get(new Integer(JournalRecordIds.ACKNOWLEDGE_CURSOR)));
+      assertNull("The system is acking page records instead of just delete data", recordsType.get(Integer.valueOf(JournalRecordIds.ACKNOWLEDGE_CURSOR)));
 
       Pair<List<RecordInfo>, List<PreparedTransactionInfo>> journalData = loadMessageJournal(config);
 
@@ -1461,13 +1461,13 @@ public class PagingTest extends ActiveMQTestBase {
             DescribeJournal.ReferenceDescribe ref = (ReferenceDescribe) DescribeJournal.newObjectEncoding(info);
 
             if (ref.refEncoding.queueID == deletedQueueID) {
-               deletedQueueReferences.add(new Long(info.id));
+               deletedQueueReferences.add(Long.valueOf(info.id));
             }
          } else if (info.getUserRecordType() == JournalRecordIds.ACKNOWLEDGE_REF) {
             AckDescribe ref = (AckDescribe) DescribeJournal.newObjectEncoding(info);
 
             if (ref.refEncoding.queueID == deletedQueueID) {
-               deletedQueueReferences.remove(new Long(info.id));
+               deletedQueueReferences.remove(Long.valueOf(info.id));
             }
          }
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
@@ -118,7 +118,7 @@ public class XmlImportExportTest extends ActiveMQTestBase {
          ClientMessage msg = session.createMessage(true);
          msg.getBodyBuffer().writeString("Bob the giant pig " + i);
          msg.putBooleanProperty("myBooleanProperty", Boolean.TRUE);
-         msg.putByteProperty("myByteProperty", new Byte("0"));
+         msg.putByteProperty("myByteProperty", Byte.valueOf("0"));
          msg.putBytesProperty("myBytesProperty", new byte[]{0, 1, 2, 3, 4});
          msg.putDoubleProperty("myDoubleProperty", i * 1.6);
          msg.putFloatProperty("myFloatProperty", i * 2.5F);
@@ -126,7 +126,7 @@ public class XmlImportExportTest extends ActiveMQTestBase {
          msg.putLongProperty("myLongProperty", Long.MAX_VALUE - i);
          msg.putObjectProperty("myObjectProperty", i);
          msg.putObjectProperty("myNullObjectProperty", null);
-         msg.putShortProperty("myShortProperty", new Integer(i).shortValue());
+         msg.putShortProperty("myShortProperty", Integer.valueOf(i).shortValue());
          msg.putStringProperty("myStringProperty", "myStringPropertyValue_" + i);
          msg.putStringProperty("myNullStringProperty", null);
          msg.putStringProperty("myNonAsciiStringProperty", international.toString());
@@ -166,7 +166,7 @@ public class XmlImportExportTest extends ActiveMQTestBase {
          msg.getBodyBuffer().readBytes(body);
          assertTrue(new String(body).contains("Bob the giant pig " + i));
          assertEquals(msg.getBooleanProperty("myBooleanProperty"), Boolean.TRUE);
-         assertEquals(msg.getByteProperty("myByteProperty"), new Byte("0"));
+         assertEquals(msg.getByteProperty("myByteProperty"), Byte.valueOf("0"));
          byte[] bytes = msg.getBytesProperty("myBytesProperty");
          for (int j = 0; j < 5; j++) {
             assertEquals(j, bytes[j]);
@@ -178,7 +178,7 @@ public class XmlImportExportTest extends ActiveMQTestBase {
          assertEquals(i, msg.getObjectProperty("myObjectProperty"));
          assertEquals(true, msg.getPropertyNames().contains(SimpleString.toSimpleString("myNullObjectProperty")));
          assertEquals(null, msg.getObjectProperty("myNullObjectProperty"));
-         assertEquals(new Integer(i).shortValue(), msg.getShortProperty("myShortProperty").shortValue());
+         assertEquals(Integer.valueOf(i).shortValue(), msg.getShortProperty("myShortProperty").shortValue());
          assertEquals("myStringPropertyValue_" + i, msg.getStringProperty("myStringProperty"));
          assertEquals(true, msg.getPropertyNames().contains(SimpleString.toSimpleString("myNullStringProperty")));
          assertEquals(null, msg.getStringProperty("myNullStringProperty"));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
@@ -518,14 +518,14 @@ public class ScaleDownTest extends ClusterTestBase {
          ClientMessage msg = session.createMessage(true);
          msg.getBodyBuffer().writeString("Bob the giant pig " + i);
          msg.putBooleanProperty("myBooleanProperty", Boolean.TRUE);
-         msg.putByteProperty("myByteProperty", new Byte("0"));
+         msg.putByteProperty("myByteProperty", Byte.valueOf("0"));
          msg.putBytesProperty("myBytesProperty", new byte[]{0, 1, 2, 3, 4});
          msg.putDoubleProperty("myDoubleProperty", i * 1.6);
          msg.putFloatProperty("myFloatProperty", i * 2.5F);
          msg.putIntProperty("myIntProperty", i);
          msg.putLongProperty("myLongProperty", Long.MAX_VALUE - i);
          msg.putObjectProperty("myObjectProperty", i);
-         msg.putShortProperty("myShortProperty", new Integer(i).shortValue());
+         msg.putShortProperty("myShortProperty", Integer.valueOf(i).shortValue());
          msg.putStringProperty("myStringProperty", "myStringPropertyValue_" + i);
          msg.putStringProperty("myNonAsciiStringProperty", international.toString());
          msg.putStringProperty("mySpecialCharacters", special);
@@ -545,7 +545,7 @@ public class ScaleDownTest extends ClusterTestBase {
          msg.getBodyBuffer().readBytes(body);
          Assert.assertTrue(new String(body).contains("Bob the giant pig " + i));
          Assert.assertEquals(msg.getBooleanProperty("myBooleanProperty"), Boolean.TRUE);
-         Assert.assertEquals(msg.getByteProperty("myByteProperty"), new Byte("0"));
+         Assert.assertEquals(msg.getByteProperty("myByteProperty"), Byte.valueOf("0"));
          byte[] bytes = msg.getBytesProperty("myBytesProperty");
          for (int j = 0; j < 5; j++) {
             Assert.assertEquals(j, bytes[j]);
@@ -555,7 +555,7 @@ public class ScaleDownTest extends ClusterTestBase {
          Assert.assertEquals(i, msg.getIntProperty("myIntProperty").intValue());
          Assert.assertEquals(Long.MAX_VALUE - i, msg.getLongProperty("myLongProperty").longValue());
          Assert.assertEquals(i, msg.getObjectProperty("myObjectProperty"));
-         Assert.assertEquals(new Integer(i).shortValue(), msg.getShortProperty("myShortProperty").shortValue());
+         Assert.assertEquals(Integer.valueOf(i).shortValue(), msg.getShortProperty("myShortProperty").shortValue());
          Assert.assertEquals("myStringPropertyValue_" + i, msg.getStringProperty("myStringProperty"));
          Assert.assertEquals(international.toString(), msg.getStringProperty("myNonAsciiStringProperty"));
          Assert.assertEquals(special, msg.getStringProperty("mySpecialCharacters"));

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/BodyIsAssignableFromTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/BodyIsAssignableFromTest.java
@@ -128,8 +128,8 @@ public class BodyIsAssignableFromTest extends MessageBodyTestCase {
             msg = queueProducerSession.createStreamMessage();
             break;
          case OBJECT:
-            res = new Double(37.6);
-            msg = queueProducerSession.createObjectMessage(new Double(37.6));
+            res = Double.valueOf(37.6);
+            msg = queueProducerSession.createObjectMessage(Double.valueOf(37.6));
             break;
          case MAP:
             MapMessage msg1 = queueProducerSession.createMapMessage();

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/BytesMessageTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/BytesMessageTest.java
@@ -87,8 +87,8 @@ public class BytesMessageTest extends MessageTestBase {
       ProxyAssertSupport.assertEquals((byte) 5, bytes[1]);
       ProxyAssertSupport.assertEquals((byte) 6, bytes[2]);
       ProxyAssertSupport.assertEquals((char) 7, bm.readChar());
-      ProxyAssertSupport.assertEquals(new Double(8.0), new Double(bm.readDouble()));
-      ProxyAssertSupport.assertEquals(new Float(9.0), new Float(bm.readFloat()));
+      ProxyAssertSupport.assertEquals(Double.valueOf(8.0), Double.valueOf(bm.readDouble()));
+      ProxyAssertSupport.assertEquals(Float.valueOf(9.0f), Float.valueOf(bm.readFloat()));
       ProxyAssertSupport.assertEquals(10, bm.readInt());
       ProxyAssertSupport.assertEquals(11L, bm.readLong());
       ProxyAssertSupport.assertEquals((short) 12, bm.readShort());

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MapMessageTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MapMessageTest.java
@@ -104,8 +104,8 @@ public class MapMessageTest extends MessageTestBase {
       ProxyAssertSupport.assertEquals((byte) 4, bytes[1]);
       ProxyAssertSupport.assertEquals((byte) 5, bytes[2]);
       ProxyAssertSupport.assertEquals((char) 6, mm.getChar("char"));
-      ProxyAssertSupport.assertEquals(new Double(7.0), new Double(mm.getDouble("double")));
-      ProxyAssertSupport.assertEquals(new Float(8.0f), new Float(mm.getFloat("float")));
+      ProxyAssertSupport.assertEquals(Double.valueOf(7.0), Double.valueOf(mm.getDouble("double")));
+      ProxyAssertSupport.assertEquals(Float.valueOf(8.0f), Float.valueOf(mm.getFloat("float")));
       ProxyAssertSupport.assertEquals(9, mm.getInt("int"));
       ProxyAssertSupport.assertEquals(10L, mm.getLong("long"));
       ProxyAssertSupport.assertEquals("this is an object", mm.getObject("object"));

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageBodyTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageBodyTest.java
@@ -76,13 +76,13 @@ public class MessageBodyTest extends MessageBodyTestCase {
       m.writeBytes(myBytes);
       m.writeBytes(myBytes, 2, 3);
 
-      m.writeObject(new Boolean(myBool));
-      m.writeObject(new Byte(myByte));
-      m.writeObject(new Short(myShort));
-      m.writeObject(new Integer(myInt));
-      m.writeObject(new Long(myLong));
-      m.writeObject(new Float(myFloat));
-      m.writeObject(new Double(myDouble));
+      m.writeObject(Boolean.valueOf(myBool));
+      m.writeObject(Byte.valueOf(myByte));
+      m.writeObject(Short.valueOf(myShort));
+      m.writeObject(Integer.valueOf(myInt));
+      m.writeObject(Long.valueOf(myLong));
+      m.writeObject(Float.valueOf(myFloat));
+      m.writeObject(Double.valueOf(myDouble));
       m.writeObject(myString);
       m.writeObject(myBytes);
 
@@ -434,13 +434,13 @@ public class MessageBodyTest extends MessageBodyTestCase {
       m1.setDouble("myDouble", myDouble);
       m1.setString("myString", myString);
 
-      m1.setObject("myBool", new Boolean(myBool));
-      m1.setObject("myByte", new Byte(myByte));
-      m1.setObject("myShort", new Short(myShort));
-      m1.setObject("myInt", new Integer(myInt));
-      m1.setObject("myLong", new Long(myLong));
-      m1.setObject("myFloat", new Float(myFloat));
-      m1.setObject("myDouble", new Double(myDouble));
+      m1.setObject("myBool", Boolean.valueOf(myBool));
+      m1.setObject("myByte", Byte.valueOf(myByte));
+      m1.setObject("myShort", Short.valueOf(myShort));
+      m1.setObject("myInt", Integer.valueOf(myInt));
+      m1.setObject("myLong", Long.valueOf(myLong));
+      m1.setObject("myFloat", Float.valueOf(myFloat));
+      m1.setObject("myDouble", Double.valueOf(myDouble));
       m1.setObject("myString", myString);
 
       try {
@@ -933,13 +933,13 @@ public class MessageBodyTest extends MessageBodyTestCase {
       m.writeBytes(myBytes);
       m.writeBytes(myBytes, 2, 3);
 
-      m.writeObject(new Boolean(myBool));
-      m.writeObject(new Byte(myByte));
-      m.writeObject(new Short(myShort));
-      m.writeObject(new Integer(myInt));
-      m.writeObject(new Long(myLong));
-      m.writeObject(new Float(myFloat));
-      m.writeObject(new Double(myDouble));
+      m.writeObject(Boolean.valueOf(myBool));
+      m.writeObject(Byte.valueOf(myByte));
+      m.writeObject(Short.valueOf(myShort));
+      m.writeObject(Integer.valueOf(myInt));
+      m.writeObject(Long.valueOf(myLong));
+      m.writeObject(Float.valueOf(myFloat));
+      m.writeObject(Double.valueOf(myDouble));
       m.writeObject(myString);
       m.writeObject(myBytes);
 

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
@@ -180,13 +180,13 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
       m1.setDoubleProperty("myDouble", myDouble);
       m1.setStringProperty("myString", myString);
 
-      m1.setObjectProperty("myBool", new Boolean(myBool));
-      m1.setObjectProperty("myByte", new Byte(myByte));
-      m1.setObjectProperty("myShort", new Short(myShort));
-      m1.setObjectProperty("myInt", new Integer(myInt));
-      m1.setObjectProperty("myLong", new Long(myLong));
-      m1.setObjectProperty("myFloat", new Float(myFloat));
-      m1.setObjectProperty("myDouble", new Double(myDouble));
+      m1.setObjectProperty("myBool", Boolean.valueOf(myBool));
+      m1.setObjectProperty("myByte", Byte.valueOf(myByte));
+      m1.setObjectProperty("myShort", Short.valueOf(myShort));
+      m1.setObjectProperty("myInt", Integer.valueOf(myInt));
+      m1.setObjectProperty("myLong", Long.valueOf(myLong));
+      m1.setObjectProperty("myFloat", Float.valueOf(myFloat));
+      m1.setObjectProperty("myDouble", Double.valueOf(myDouble));
       m1.setObjectProperty("myString", myString);
 
       try {

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageTestBase.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageTestBase.java
@@ -198,8 +198,8 @@ public abstract class MessageTestBase extends ActiveMQServerTestCase {
       ProxyAssertSupport.assertNotNull(m);
       ProxyAssertSupport.assertEquals(true, m.getBooleanProperty("booleanProperty"));
       ProxyAssertSupport.assertEquals((byte) 3, m.getByteProperty("byteProperty"));
-      ProxyAssertSupport.assertEquals(new Double(4.0), new Double(m.getDoubleProperty("doubleProperty")));
-      ProxyAssertSupport.assertEquals(new Float(5.0f), new Float(m.getFloatProperty("floatProperty")));
+      ProxyAssertSupport.assertEquals(Double.valueOf(4.0), Double.valueOf(m.getDoubleProperty("doubleProperty")));
+      ProxyAssertSupport.assertEquals(Float.valueOf(5.0f), Float.valueOf(m.getFloatProperty("floatProperty")));
       ProxyAssertSupport.assertEquals(6, m.getIntProperty("intProperty"));
       ProxyAssertSupport.assertEquals(7, m.getLongProperty("longProperty"));
       ProxyAssertSupport.assertEquals((short) 8, m.getShortProperty("shortProperty"));

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSMapMessage.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSMapMessage.java
@@ -62,7 +62,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Byte(value));
+      content.put(name, Byte.valueOf(value));
 
    }
 
@@ -73,7 +73,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Short(value));
+      content.put(name, Short.valueOf(value));
 
    }
 
@@ -84,7 +84,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Character(value));
+      content.put(name, Character.valueOf(value));
 
    }
 
@@ -95,7 +95,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Integer(value));
+      content.put(name, Integer.valueOf(value));
 
    }
 
@@ -106,7 +106,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Long(value));
+      content.put(name, Long.valueOf(value));
 
    }
 
@@ -117,7 +117,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Float(value));
+      content.put(name, Float.valueOf(value));
 
    }
 
@@ -128,7 +128,7 @@ public class SimpleJMSMapMessage extends SimpleJMSMessage implements MapMessage 
          throw new MessageNotWriteableException("Message is ReadOnly !");
       }
 
-      content.put(name, new Double(value));
+      content.put(name, Double.valueOf(value));
 
    }
 

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSMessage.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSMessage.java
@@ -35,7 +35,7 @@ public class SimpleJMSMessage implements Message {
    // Constructors --------------------------------------------------
 
    public SimpleJMSMessage() {
-      properties.put("JMSXDeliveryCount", new Integer(0));
+      properties.put("JMSXDeliveryCount", Integer.valueOf(0));
    }
 
    /*
@@ -294,37 +294,37 @@ public class SimpleJMSMessage implements Message {
 
    @Override
    public void setBooleanProperty(final String name, final boolean value) throws JMSException {
-      properties.put(name, new Boolean(value));
+      properties.put(name, Boolean.valueOf(value));
    }
 
    @Override
    public void setByteProperty(final String name, final byte value) throws JMSException {
-      properties.put(name, new Byte(value));
+      properties.put(name, Byte.valueOf(value));
    }
 
    @Override
    public void setShortProperty(final String name, final short value) throws JMSException {
-      properties.put(name, new Short(value));
+      properties.put(name, Short.valueOf(value));
    }
 
    @Override
    public void setIntProperty(final String name, final int value) throws JMSException {
-      properties.put(name, new Integer(value));
+      properties.put(name, Integer.valueOf(value));
    }
 
    @Override
    public void setLongProperty(final String name, final long value) throws JMSException {
-      properties.put(name, new Long(value));
+      properties.put(name, Long.valueOf(value));
    }
 
    @Override
    public void setFloatProperty(final String name, final float value) throws JMSException {
-      properties.put(name, new Float(value));
+      properties.put(name, Float.valueOf(value));
    }
 
    @Override
    public void setDoubleProperty(final String name, final double value) throws JMSException {
-      properties.put(name, new Double(value));
+      properties.put(name, Double.valueOf(value));
    }
 
    @Override

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSStreamMessage.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SimpleJMSStreamMessage.java
@@ -397,7 +397,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Boolean(value));
+      content.add(Boolean.valueOf(value));
    }
 
    @Override
@@ -405,7 +405,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Byte(value));
+      content.add(Byte.valueOf(value));
    }
 
    @Override
@@ -413,7 +413,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Short(value));
+      content.add(Short.valueOf(value));
    }
 
    @Override
@@ -421,7 +421,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Character(value));
+      content.add(Character.valueOf(value));
    }
 
    @Override
@@ -429,7 +429,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Integer(value));
+      content.add(Integer.valueOf(value));
    }
 
    @Override
@@ -437,7 +437,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Long(value));
+      content.add(Long.valueOf(value));
    }
 
    @Override
@@ -445,7 +445,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Float(value));
+      content.add(Float.valueOf(value));
    }
 
    @Override
@@ -453,7 +453,7 @@ public class SimpleJMSStreamMessage extends SimpleJMSMessage implements StreamMe
       if (!bodyWriteOnly) {
          throw new MessageNotWriteableException("The message body is readonly");
       }
-      content.add(new Double(value));
+      content.add(Double.valueOf(value));
    }
 
    @Override

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/StreamMessageTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/StreamMessageTest.java
@@ -106,8 +106,8 @@ public class StreamMessageTest extends MessageTestBase {
       ProxyAssertSupport.assertEquals((byte) 6, bytes[2]);
       ProxyAssertSupport.assertEquals(-1, sm.readBytes(bytes));
       ProxyAssertSupport.assertEquals((char) 7, sm.readChar());
-      ProxyAssertSupport.assertEquals(new Double(8.0), new Double(sm.readDouble()));
-      ProxyAssertSupport.assertEquals(new Float(9.0), new Float(sm.readFloat()));
+      ProxyAssertSupport.assertEquals(Double.valueOf(8.0), Double.valueOf(sm.readDouble()));
+      ProxyAssertSupport.assertEquals(Float.valueOf(9.0f), Float.valueOf(sm.readFloat()));
       ProxyAssertSupport.assertEquals(10, sm.readInt());
       ProxyAssertSupport.assertEquals(11L, sm.readLong());
       ProxyAssertSupport.assertEquals("this is an object", sm.readObject());

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/tools/container/InVMInitialContextFactory.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/tools/container/InVMInitialContextFactory.java
@@ -88,12 +88,12 @@ public class InVMInitialContextFactory implements InitialContextFactory {
       // Note! This MUST be synchronized
       synchronized (InVMInitialContextFactory.initialContexts) {
 
-         InVMContext ic = (InVMContext) InVMInitialContextFactory.initialContexts.get(new Integer(serverIndex));
+         InVMContext ic = (InVMContext) InVMInitialContextFactory.initialContexts.get(Integer.valueOf(serverIndex));
 
          if (ic == null) {
             ic = new InVMContext(s);
             ic.bind("java:/", new InVMContext(s));
-            InVMInitialContextFactory.initialContexts.put(new Integer(serverIndex), ic);
+            InVMInitialContextFactory.initialContexts.put(Integer.valueOf(serverIndex), ic);
          }
 
          return ic;

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/util/JNDIUtilTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/util/JNDIUtilTest.java
@@ -46,7 +46,7 @@ public class JNDIUtilTest extends ActiveMQServerTestCase {
          // OK
       }
 
-      JNDIUtil.rebind(ic, "/nosuchsubcontext/sub1/sub2/sub3/name", new Integer(7));
+      JNDIUtil.rebind(ic, "/nosuchsubcontext/sub1/sub2/sub3/name", Integer.valueOf(7));
 
       ProxyAssertSupport.assertEquals(7, ((Integer) ic.lookup("/nosuchsubcontext/sub1/sub2/sub3/name")).intValue());
    }
@@ -60,7 +60,7 @@ public class JNDIUtilTest extends ActiveMQServerTestCase {
          // OK
       }
 
-      JNDIUtil.rebind(ic, "/doesnotexistyet", new Integer(8));
+      JNDIUtil.rebind(ic, "/doesnotexistyet", Integer.valueOf(8));
 
       ProxyAssertSupport.assertEquals(8, ((Integer) ic.lookup("/doesnotexistyet")).intValue());
 
@@ -76,7 +76,7 @@ public class JNDIUtilTest extends ActiveMQServerTestCase {
          // OK
       }
 
-      JNDIUtil.rebind(ic, "doesnotexistyet", new Integer(9));
+      JNDIUtil.rebind(ic, "doesnotexistyet", Integer.valueOf(9));
 
       ProxyAssertSupport.assertEquals(9, ((Integer) ic.lookup("/doesnotexistyet")).intValue());
 

--- a/tests/joram-tests/src/test/java/org/objectweb/jtests/jms/conform/message/MessageTypeTest.java
+++ b/tests/joram-tests/src/test/java/org/objectweb/jtests/jms/conform/message/MessageTypeTest.java
@@ -226,7 +226,7 @@ public class MessageTypeTest extends PTPTestCase {
       try {
          Vector<Object> vector = new Vector<>();
          vector.add("pi");
-         vector.add(new Double(3.14159));
+         vector.add(Double.valueOf(3.14159));
 
          ObjectMessage message = senderSession.createObjectMessage();
          message.setObject(vector);

--- a/tests/joram-tests/src/test/java/org/objectweb/jtests/jms/conform/message/properties/MessagePropertyTest.java
+++ b/tests/joram-tests/src/test/java/org/objectweb/jtests/jms/conform/message/properties/MessagePropertyTest.java
@@ -59,7 +59,7 @@ public class MessagePropertyTest extends PTPTestCase {
    public void testSetObjectProperty_1() {
       try {
          Message message = senderSession.createMessage();
-         message.setObjectProperty("pi", new Float(3.14159f));
+         message.setObjectProperty("pi", Float.valueOf(3.14159f));
          Assert.assertEquals(3.14159f, message.getFloatProperty("pi"), 0);
       } catch (JMSException e) {
          fail(e);


### PR DESCRIPTION
…moval since Java 16

updates all the uses in tests, missed in original commit