### PR TITLE
NO-JIRA AssertionLoggerHandler improvements

### DIFF
--- a/tests/config/logging-CI.properties
+++ b/tests/config/logging-CI.properties
@@ -15,26 +15,25 @@
 # limitations under the License.
 #
 
-
-# This is the logger used only on CI environments
-
 # Additional logger names to configure (root logger is always configured)
 # Root logger option
-loggers=org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms,org.apache.activemq.artemis.ra,org.apache.activemq.artemis.tests.unit,org.apache.activemq.artemis.tests.integration,org.apache.activemq.artemis.jms.tests,org.apache.activemq.cli.test,org.apache.activemq.audit
+loggers=org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.core.journal,org.apache.activemq.artemis.jms,org.apache.activemq.artemis.ra,org.apache.activemq.artemis.tests.smoke,org.apache.activemq.artemis.tests.unit,org.apache.activemq.artemis.tests.integration,org.apache.activemq.artemis.jms.tests,org.apache.activemq.cli.test,org.apache.activemq.audit,org.apache.activemq.audit.message
 
 # Root logger level
-logger.level=WARN
+logger.level=INFO
 # ActiveMQ Artemis logger levels
-logger.org.apache.activemq.artemis.core.server.level=WARN
-logger.org.apache.activemq.artemis.journal.level=WARN
-logger.org.apache.activemq.artemis.utils.level=WARN
-logger.org.apache.activemq.artemis.jms.level=WARN
-logger.org.apache.activemq.artemis.ra.level=WARN
+logger.org.apache.activemq.artemis.core.server.level=INFO
+logger.org.apache.activemq.artemis.core.journal.level=INFO
+logger.org.apache.activemq.artemis.utils.level=INFO
+logger.org.apache.activemq.artemis.jms.level=INFO
+logger.org.apache.activemq.artemis.ra.level=INFO
 
-logger.org.apache.activemq.artemis.tests.integration.level=INFO
-logger.org.apache.activemq.artemis.tests.level=INFO
-logger.org.apache.activemq.artemis.tests.unit.level=INFO
-logger.org.apache.activemq.artemis.jms.tests.level=INFO
+logger.org.apache.activemq.cli.test.level=DEBUG
+logger.org.apache.activemq.artemis.tests.integration.level=DEBUG
+logger.org.apache.activemq.artemis.tests.level=DEBUG
+logger.org.apache.activemq.artemis.tests.unit.level=DEBUG
+logger.org.apache.activemq.artemis.jms.tests.level=DEBUG
+logger.org.apache.activemq.artemis.tests.smoke.level=DEBUG
 
 
 # Root logger handlers
@@ -49,13 +48,13 @@ logger.org.apache.activemq.audit.useParentHandlers=false
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=FINE
+handler.CONSOLE.level=WARN
 handler.CONSOLE.autoFlush=true
 handler.CONSOLE.formatter=PATTERN
 
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=FINE
+handler.FILE.level=WARN
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=target/activemq.log

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/logging/AssertionLoggerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/logging/AssertionLoggerTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.logging;
+
+import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
+import org.apache.activemq.artemis.protocol.amqp.broker.ActiveMQProtonRemotingConnection;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolLogger;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This will validate the AssertionLoggerHandler is working as expected.
+ * Even though this class belongs to artemis commons, this test has to be done here as we
+ * are validating the logging.properties, and logging-ci.properties and the classloading of everything.
+ */
+public class AssertionLoggerTest {
+
+   @Before
+   public void prepare() {
+      AssertionLoggerHandler.startCapture(true);
+   }
+
+   @After
+   public void cleanup() {
+      AssertionLoggerHandler.stopCapture();
+   }
+
+   @Test
+   public void testHandlingOnAMQP() throws Exception {
+      validateLogging(ActiveMQProtonRemotingConnection.class);
+   }
+
+   @Test
+   public void testHandlingOnClientCore() throws Exception {
+      validateLogging(ServerLocatorImpl.class);
+   }
+
+   @Test
+   public void testInfoAMQP() throws Exception {
+      ActiveMQAMQPProtocolLogger.LOGGER.retryConnection("test", "test", 1, 1);
+      Assert.assertTrue(AssertionLoggerHandler.findText("AMQ111002"));
+   }
+
+   private void validateLogging(Class clazz) {
+      String randomLogging = RandomUtil.randomString();
+      Logger logging = Logger.getLogger(clazz);
+      logging.warn(randomLogging);
+      Assert.assertTrue(AssertionLoggerHandler.findText(randomLogging));
+
+      AssertionLoggerHandler.clear();
+
+      for (int i = 0; i < 10; i++) {
+         logging.warn(randomLogging);
+      }
+      Assert.assertEquals(10, AssertionLoggerHandler.countText(randomLogging));
+
+      AssertionLoggerHandler.clear();
+
+      for (int i = 0; i < 10; i++) {
+         logging.info(randomLogging);
+      }
+
+      Assert.assertEquals(10, AssertionLoggerHandler.countText(randomLogging));
+   }
+}


### PR DESCRIPTION
I decided on NO-JIRA as this is only support tests themselves. No need for release notes on this commit:

I changed logging-CI.properties to be the same as logging.properties, with the only exception as file and console are limited by WARN.
while the AssertionLogger would still get INFO. as that's required for certain tests.