### PR TITLE
ARTEMIS-3407: update pax-exam to 4.13.4 and karaf to 4.3.1, get tests…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
       <logging.config>logging.properties</logging.config>
 
       <activemq-artemis-native-version>1.0.2</activemq-artemis-native-version>
-      <karaf.version>4.3.0</karaf.version>
-      <pax.exam.version>4.9.1</pax.exam.version>
+      <karaf.version>4.3.1</karaf.version>
+      <pax.exam.version>4.13.4</pax.exam.version>
       <commons.config.version>2.7</commons.config.version>
       <commons.lang.version>3.12.0</commons.lang.version>
       <activemq5-version>5.16.0</activemq5-version>

--- a/tests/karaf-client-integration-tests/pom.xml
+++ b/tests/karaf-client-integration-tests/pom.xml
@@ -25,7 +25,7 @@
 
    <artifactId>karaf-client-integration-tests</artifactId>
    <packaging>jar</packaging>
-   <name>ActiveMQ Artemis Client Integration Tests</name>
+   <name>ActiveMQ Artemis Karaf Client Integration Tests</name>
 
    <description>
       Integration tests for the artemis client features using Apache Karaf


### PR DESCRIPTION
… working on Java 11

Also tweaks karaf test module name for clarity