### PR TITLE
ARTEMIS-3397 remove queue rate metric from web console

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueField.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueField.java
@@ -31,7 +31,7 @@ public enum QueueField {
    DELIVERING_COUNT("deliveringCount"),
    MESSAGES_ADDED("messagesAdded"),
    MESSAGES_ACKED("messagesAcked"),
-   RATE("rate"),
+   MESSAGES_EXPIRED("messagesExpired"),
    ROUTING_TYPE("routingType"),
    USER("user"),
    AUTO_CREATED("autoCreated"),

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueView.java
@@ -49,7 +49,6 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
          .add(QueueField.NAME.getName(), toString(queue.getName()))
          .add(QueueField.ADDRESS.getName(), toString(queue.getAddress()))
          .add(QueueField.FILTER.getName(), toString(queue.getFilter()))
-         .add(QueueField.RATE.getName(), toString(q.getRate()))
          .add(QueueField.DURABLE.getName(), toString(queue.isDurable()))
          .add(QueueField.PAUSED.getName(), toString(q.isPaused()))
          .add(QueueField.TEMPORARY.getName(), toString(queue.isTemporary()))
@@ -62,6 +61,7 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
          .add(QueueField.MESSAGES_ADDED.getName(), toString(queue.getMessagesAdded()))
          .add(QueueField.MESSAGE_COUNT.getName(), toString(queue.getMessageCount()))
          .add(QueueField.MESSAGES_ACKED.getName(), toString(queue.getMessagesAcknowledged()))
+         .add(QueueField.MESSAGES_EXPIRED.getName(), toString(queue.getMessagesExpired()))
          .add(QueueField.DELIVERING_COUNT.getName(), toString(queue.getDeliveringCount()))
          .add(QueueField.MESSAGES_KILLED.getName(), toString(queue.getMessagesKilled()))
          .add(QueueField.DIRECT_DELIVER.getName(), toString(q.isDirectDeliver()))
@@ -95,8 +95,6 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
             return queue.getAddress();
          case FILTER:
             return queue.getFilter();
-         case RATE:
-            return q.getRate();
          case DURABLE:
             return queue.isDurable();
          case PAUSED:
@@ -121,6 +119,8 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
             return queue.getMessageCount();
          case MESSAGES_ACKED:
             return queue.getMessagesAcknowledged();
+         case MESSAGES_EXPIRED:
+            return queue.getMessagesExpired();
          case DELIVERING_COUNT:
             return queue.getDeliveringCount();
          case MESSAGES_KILLED:

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/QueueFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/QueueFilterPredicate.java
@@ -68,7 +68,7 @@ public class QueueFilterPredicate extends ActiveMQFilterPredicate<QueueControl> 
                return matches(queue.getMessagesAdded());
             case MESSAGES_ACKED:
                return matches(queue.getMessagesAcknowledged());
-            case RATE:
+            case MESSAGES_EXPIRED:
                return matches(queue.getMessagesExpired());
             case ROUTING_TYPE:
                return matches(queue.getRoutingType());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -486,8 +486,6 @@ public interface Queue extends Bindable,CriticalComponent {
 
    void postAcknowledge(MessageReference ref, AckReason reason);
 
-   float getRate();
-
    /**
     * @return the user associated with this queue
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -4033,8 +4033,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       messagesKilled.set(0);
    }
 
-   @Override
-   public float getRate() {
+   private float getRate() {
       long locaMessageAdded = getMessagesAdded();
       float timeSlice = ((System.currentTimeMillis() - queueRateCheckTime.getAndSet(System.currentTimeMillis())) / 1000.0f);
       if (timeSlice == 0) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1632,11 +1632,6 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
-      public float getRate() {
-         return 0.0f;
-      }
-
-      @Override
       public SimpleString getUser() {
          return null;
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -963,11 +963,6 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
-   public float getRate() {
-      return 0.0f;
-   }
-
-   @Override
    public SimpleString getUser() {
       return null;
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.server.impl;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -210,7 +211,7 @@ public class QueueImplTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void testRate() throws InterruptedException {
+   public void testRate() throws Exception {
       QueueImpl queue = getTemporaryQueue();
 
       final int numMessages = 10;
@@ -223,7 +224,10 @@ public class QueueImplTest extends ActiveMQTestBase {
 
       Thread.sleep(1000);
 
-      float rate = queue.getRate();
+      Method getRate = QueueImpl.class.getDeclaredMethod("getRate", null);
+      getRate.setAccessible(true);
+      float rate = (float) getRate.invoke(queue, null);
+
       Assert.assertTrue(rate <= 10.0f);
       log.debug("Rate: " + rate);
    }


### PR DESCRIPTION
This is a follow-up from ARTEMIS-2322.

The changes related to expired message are only there because
QueueFilterPredicate had a bug where the rate was correlated to expired
messages. When I fixed that I noticed that expired messages was actually
missing so I added it.