### PR TITLE
ARTEMIS-3401 use regex on web console for DLQ & expiry

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/html/preferences.html
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/html/preferences.html
@@ -39,8 +39,8 @@
 
   <div class="form-group">
     <label class="col-md-2 control-label" for="artemisDLQ">
-      The DLQ of the Broker
-      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="The Dead Letter Queue of the Broker"></span>
+      Dead-letter address regex
+      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="A regular expression to match one or more dead-letter addresses"></span>
     </label>
     <div class="col-md-6">
       <input type="text" id="artemisDLQ" ng-model="artemisDLQ">
@@ -49,8 +49,8 @@
 
   <div class="form-group">
     <label class="col-md-2 control-label" for="artemisExpiryQueue">
-      The Expiry of the Broker
-      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="The Expiry Queue of the Broker"></span>
+      Expiry address regex
+      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="A regular expression to match one or more expiry addresses"></span>
     </label>
     <div class="col-md-6">
       <input type="text" id="artemisExpiryQueue" ng-model="artemisExpiryQueue">

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
@@ -218,13 +218,13 @@ var Artemis;
             var node = workspace.keyToNodeMap[key];
             objName = node.objectName;
         }
-        var artemisDLQ = localStorage['artemisDLQ'] || "DLQ";
-        var artemisExpiryQueue = localStorage['artemisExpiryQueue'] || "ExpiryQueue";
+        var artemisDLQ = localStorage['artemisDLQ'] || "^DLQ$";
+        var artemisExpiryQueue = localStorage['artemisExpiryQueue'] || "^ExpiryQueue$";
         Artemis.log.debug("loading table" + artemisExpiryQueue);
         if (objName) {
             ctrl.dlq = false;
             var addressName = jolokia.getAttribute(objName, "Address");
-            if (addressName == artemisDLQ || addressName == artemisExpiryQueue) {
+            if (addressName.match(artemisDLQ) != null || addressName.match(artemisExpiryQueue) != null) {
                 ctrl.dlq = true;
             }
         }
@@ -826,10 +826,10 @@ var Artemis;
             if (objName) {
                 ctrl.dlq = false;
                 var addressName = jolokia.getAttribute(objName, "Address");
-                var artemisDLQ = localStorage['artemisDLQ'] || "DLQ";
-                var artemisExpiryQueue = localStorage['artemisExpiryQueue'] || "ExpiryQueue";
+                var artemisDLQ = localStorage['artemisDLQ'] || "^DLQ$";
+                var artemisExpiryQueue = localStorage['artemisExpiryQueue'] || "^ExpiryQueue$";
                 Artemis.log.debug("loading table" + artemisExpiryQueue);
-                if (addressName == artemisDLQ || addressName == artemisExpiryQueue) {
+                if (addressName.match(artemisDLQ) != null || addressName.match(artemisExpiryQueue) != null) {
                     onDlq(true);
                 } else {
                     onDlq(false);

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/preferences.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/preferences.js
@@ -26,10 +26,10 @@ var Artemis;
                 'value': userDetails.password ? userDetails.password : ""
              },
              'artemisDLQ': {
-                'value': "DLQ"
+                'value': "^DLQ$"
              },
              'artemisExpiryQueue': {
-                'value': "ExpiryQueue"
+                'value': "^ExpiryQueue$"
              },
              'ArtemisBrowseBytesMessages': {
                  'value': 99,
@@ -71,8 +71,8 @@ var Artemis;
 
                   <div class="form-group">
                     <label class="col-md-2 control-label" for="artemisDLQ">
-                      The DLQ of the Broker
-                      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="The Dead Letter Queue of the Broker"></span>
+                      Dead-letter address regex
+                      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="A regular expression to match one or more dead-letter addresses"></span>
                     </label>
                     <div class="col-md-6">
                       <input type="text" id="artemisDLQ" ng-model="artemisDLQ">
@@ -81,8 +81,8 @@ var Artemis;
 
                   <div class="form-group">
                     <label class="col-md-2 control-label" for="artemisExpiryQueue">
-                      The Expiry of the Broker
-                      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="The Expiry Queue of the Broker"></span>
+                      Expiry address regex
+                      <span class="pficon pficon-info" data-toggle="tooltip" data-placement="top" title="A regular expression to match one or more expiry addresses"></span>
                     </label>
                     <div class="col-md-6">
                       <input type="text" id="artemisExpiryQueue" ng-model="artemisExpiryQueue">


### PR DESCRIPTION
Currently dead-letter and expiry addresses can only be identified on the
web console if they perfectly match a configurable string value (i.e.
"DLQ" and "ExpiryQueue" by default respectively). However, lots of users
have multiple dead-letter and expiry addresses which follow the same
naming pattern. The web console should support using a regular
expression so all of these addresses can be properly identified.