### PR TITLE
NO-JIRA: make errorprone consistently opt-in on all JDKs as it alread…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,9 @@
           <id>jdk11to15-errorprone</id>
           <activation>
               <jdk>[11,16)</jdk>
+              <property>
+                  <name>errorprone</name>
+              </property>
           </activation>
           <build>
               <plugins>
@@ -967,7 +970,6 @@
       </profile>
       <profile>
           <id>jdk16-errorprone</id>
-          <!-- This is very slow due to all the compiler forking required, so made it opt-in with -Derrorprone -->
           <!-- TODO: MissingOverride check only warns in this profile for now, as JDK15+ added a toString method to CharSequence -->
           <activation>
               <jdk>16</jdk>


### PR DESCRIPTION
…y is on JDK8 and 16 due to required forking